### PR TITLE
Flow control

### DIFF
--- a/handle/index.js
+++ b/handle/index.js
@@ -77,6 +77,9 @@ module.exports = {
     })
   },
   downloadFile: function (directory, linkage, callback) {
+    
+    console.log(directory, linkage)
+    
     var module = this;
     this.configurePaths(directory, linkage, function (res) {
 

--- a/handle/index.js
+++ b/handle/index.js
@@ -15,8 +15,6 @@ module.exports = {
     fs.writeFile(outputXml, data, function (error) {
       if (error) {
         console.log(error);
-      } else {
-        console.log("FILE SAVED: " + outputXml);
       }
     });     
   },
@@ -33,7 +31,7 @@ module.exports = {
   },
   // Check whether an externally hosted file is hosted on an HTTP server or an
   // FTP server and then save it locally.
-  downloadFile: function (directory, file, linkage, callback) {
+  downloadFile: function (directory, file, linkage, dcallback) {
     var directory = directory.replace(/(\r\n|\n|\r)/gm,"");
     var file = file.replace(/(\r\n|\n|\r)/gm,"");
 
@@ -48,7 +46,8 @@ module.exports = {
           if (linkage.indexOf("ftp") === 0) {
             ftp.get(linkage, outputPath, function (err, res) {
               if (err) return console.log(err, res);
-              callback(null);
+              if (typeof callback === "function")
+                dcallback(null);
             })
           } 
           // Write HTTP files to local outputs folder
@@ -60,11 +59,12 @@ module.exports = {
                 response.pipe(file);
                 file.on("finish", function () {
                   file.close(callback);
-                  callback(null);
+                  if (typeof callback === "function")
+                    callback(null);
                 })
               })
               request.on("error", function (error) {
-                callback(error);
+                dcallback(error);
               })
             }
             download(linkage, outputPath);
@@ -77,11 +77,12 @@ module.exports = {
                 response.pipe(file);
                 file.on("finish", function () {
                   file.close(callback);
-                  callback(null);
+                  if (typeof callback === "function")
+                    dcallback(null);
                 })
               })
               request.on("error", function (error) {
-                callback(error);
+                dcallback(error);
               })
             }
             download(linkage, outputPath);
@@ -181,18 +182,6 @@ module.exports = {
     ]);
     archive.finalize();
   },
-  downloadLinkage: function (linkage, directory, dead) {
-    var module = this;
-    var parsedUrl = url.parse(linkage);
-    var host = parsedUrl["protocol"] + "//" + parsedUrl["host"];
-    if (_.indexOf(dead, host) !== -1  && linkage !== "" && linkage !== null) {
-      module.configurePaths(directory, linkage, function (res) {
-        module.downloadFile(res.directory, res.file, res.linkage, function (error) {
-          if (error) console.log(error);
-        });
-      })    
-    }
-  }
 };
 
 

--- a/handle/index.js
+++ b/handle/index.js
@@ -47,6 +47,10 @@ module.exports = {
       response.on("error", function (error) {
         file.end();
       })
+
+      process.on("uncaughtException", function (error) {
+        console.log("EXCEPTION: " + error);
+      })
     })
   },
   downloadHTTPS: function (linkage, path, callback) {
@@ -65,6 +69,10 @@ module.exports = {
       
       response.on("error", function (error) {
         file.end();
+      })
+
+      process.on("uncaughtException", function (error) {
+        console.log("EXCEPTION: " + error);
       })
     })
   },

--- a/handle/index.js
+++ b/handle/index.js
@@ -32,7 +32,7 @@ module.exports = {
   // Check whether an externally hosted file is hosted on an HTTP server or an
   // FTP server and then save it locally.
   downloadFTP: function (linkage, path, callback) {
-    ftp.get(linkage, outputPath, function (err, res) {
+    ftp.get(linkage, path, function (err, res) {
       if (err) return callback(err, res);
       if (typeof callback === "function")
         callback("DOWNLOADED FTP");
@@ -66,30 +66,35 @@ module.exports = {
 
       var directory = res.directory.replace(/(\r\n|\n|\r)/gm,"");
       var file = res.file.replace(/(\r\n|\n|\r)/gm,"");
+      var outputPath = path.join(directory, file);
 
       module.buildDirectory(directory, function (error) {
 
         fs.exists(directory, function (exists) {
-          if (exists) {
-
-            var outputPath = path.join(directory, file);                
+          if (exists) {                
             // Write FTP files to local outputs folder
             if (res.linkage.indexOf("ftp") === 0) {
               module.downloadFTP(res.linkage, outputPath, function () {
-                callback("DOWNLOADED FTP");
+                if (typeof callback === "function") {
+                  callback("DOWNLOADED FTP");
+                }
               })
             } 
             // Write HTTP files to local outputs folder
             else if (res.linkage.indexOf("http") === 0 && 
                      res.linkage.indexOf("https") === -1) {
               module.downloadHTTP(res.linkage, outputPath, function () {
-                callback("DOWNLOADED HTTP");
+                if (typeof callback === "function") {
+                  callback("DOWNLOADED HTTP");
+                }
               })
             }
             // Write HTTPS files to local outputs folder
             else if (res.linkage.indexOf("https") === 0) {
               module.downloadHTTPS(res.linkage, outputPath, function () {
-                callback("DOWNLOADED HTTPS");
+                if (typeof callback === "function") {
+                  callback("DOWNLOADED HTTPS");
+                }
               })
             }
           }

--- a/handle/index.js
+++ b/handle/index.js
@@ -12,22 +12,14 @@ var async = require("async");
 module.exports = {
   // Write out XML data held in-memory to a text file.
   writeXML: function (outputXml, data) { 
-    fs.writeFile(outputXml, data, function (error) {
-      if (error) {
-        console.log(error);
-      }
-    });     
-  },
-  writeLinkage: function (logFile, linkage) {
-    var date = new Date().toISOString();
-    var text = linkage + "," + date + ",\n";
-    fs.appendFile(logFile, text, function (error) {
-      if (error) throw error;
-    })
+    fs.writeFileSync(outputXml, data);
   },
   linkageLogger: function (data, log, callback) {
-    console.log(data);
-    callback();
+    fs.writeFile(log, data, function (error) {
+      if (error)
+        callback(error);
+      callback();
+    })
   },
   // Check whether an externally hosted file is hosted on an HTTP server or an
   // FTP server and then save it locally.

--- a/handle/index.js
+++ b/handle/index.js
@@ -31,25 +31,41 @@ module.exports = {
       })
   },
   downloadHTTP: function (linkage, path, callback) {
-    var file = fs.createWriteStream(path);
     http.get(linkage, function (response) {
+
+      var file = fs.createWriteStream(path);
       response.pipe(file);
-      file.on("finish", function () {
-        file.close(callback);
+
+      file.on("close", function () {
+        callback();
+      });
+
+      file.on("error", function (error) {
+        callback(error);
+      });
+
+      response.on("error", function (error) {
+        file.end();
       })
-    }).on("error", function (error) {
-      callback(error);
     })
   },
   downloadHTTPS: function (linkage, path, callback) {
-    var file = fs.createWriteStream(path);
     https.get(linkage, function (response) {
+
+      var file = fs.createWriteStream(path);
       response.pipe(file);
-      file.on("finish", function () {
-        file.close(callback);
+
+      file.on("close", function () {
+        callback();
+      });
+
+      file.on("error", function (error) {
+        callback(error);
+      });
+      
+      response.on("error", function (error) {
+        file.end();
       })
-    }).on("error", function (error) {
-      callback(error);
     })
   },
   downloadFile: function (directory, linkage, callback) {

--- a/handle/index.js
+++ b/handle/index.js
@@ -200,6 +200,7 @@ module.exports = {
 
     zipped.on("close", function () {
       console.log("Directory has been archived");
+      callback();
     });
 
     archive.on("error", function (error) {
@@ -208,7 +209,7 @@ module.exports = {
 
     archive.pipe(zipped);
     archive.bulk([
-      {expand: true, cwd: uncompressed, src: ["*"]}
+      {expand: true, cwd: uncompressed, src: ["**"]}
     ]);
     archive.finalize();
   },

--- a/index.js
+++ b/index.js
@@ -8,197 +8,76 @@ var path = require("path");
 var url = require("url");
 var fs = require("fs");
 var _ = require("underscore");
-//var archive = require("./archive");
 
 var argv = require("yargs")
   .usage("Command line utility for archiving NGDS data on Amazon S3")
 
   .alias("p", "parse")
   .describe("Parse a CSW")
-
-  .alias("u", "urls")
-  .describe("Parse and ping all of the CSW linkages")
-
-  .alias("o", "out")
-  .describe("Specify a base directory for process outputs")
   .argv;
 
 var cmdQueue = [];
 if (argv.parse) cmdQueue.push(parseCsw);
-if (argv.urls) cmdQueue.push(doEverything);
 
 async.series(cmdQueue);
 
-// Build directories for output files and start streaming XML into text files
-function taskOne (task, callback) {
-  var dirs = task["dirs"];
-  var xml = task["xml"];
-
-  var directory = path.join(dirs["record"], xml.fileId);
-  handle.buildDirectory(directory, function () {
-    var outXML = path.join(directory, xml.fileId + ".xml");
-    handle.writeXML(outXML, xml.fullRecord);
-    doDownload(xml.linkages, directory, function () {
-      callback();
-    });
-  })
-};
-
-function doDownload (linkages, directory, callback) {
-  function download (linkage) {
-    var parsedUrl = url.parse(linkage);
-    var host = parsedUrl["protocol"] + "//" + parsedUrl["host"];
-    handle.configurePaths(directory, linkage, function (res) {
-      console.log(res);
-      handle.downloadFile(res.directory, res.file, res.linkage, function (error) {
-        if (error) console.log(error);
-      });
-    })
-  }
-
-  async.each(linkages, download, function (error) {
-    if (error) {
-      callback(error);
-    } else {
-      callback();
-    }
-  })
-}
-
-// 'Glob' is a global object generated to keep track of URL status, in-memory.
-// Ping each unique base URL and return a status to the 'glob'.
-function taskTwo (glob, dirs, xml, callback) {
-  async.each(xml.linkages, function (linkage) {
-    var parsedUrl = url.parse(linkage);
-    var host = parsedUrl["protocol"] + "//" + parsedUrl["host"];
-    if (_.indexOf(glob["unique"], host) === -1) {
-      glob["unique"].push(host);  
-
-      handle.pingUrl(host, function (error, response) {
-        if (error) {
-          error["ping"] = "DEAD";
-          glob["dead"].push(error);
-          glob["status"].push(error);
-        };
-
-        if (response) {
-          response["ping"] = "ALIVE";
-          glob["status"].push(response);
-        };
-      })
-    }
-  });
-  callback(null);
-}
-
-// This function is kind of a mess right now, I'll probably work on it tonight.
-// Here we download the various kinds of data from each linkage.  The tricky 
-// part that I'm wrestling with is how to return when ALL of the links have been
-// downloaded, so that we can zip that sucka and send it to S3.
-function taskThree (glob, dirs, xml, callback) {
-  var directory = path.join(dirs["record"], xml.fileId);
-  var dead = _.map(glob["dead"], function (record) {
-    return record["linkage"];
-  });
-
-  async.each(xml.linkages, handle.downloadLinkage.bind(null, directory, dead, handle), function (error) {
-    if (error) {
-      callback(error);
-    } else {
-      console.log(directory);
-    callback(null, dirs, xml.fileId);
-    }
-  });
-}
-
-// Pretty simply, just zip up a file
-function taskFour (dirs, directory, callback) {
-  console.log(dirs, directory);
-/*
-  var uncompressed = path.join(dirs["record"], directory);
-  var compressed = path.join(dirs["archive"], directory + ".zip");
-  handle.compressDirectory(uncompressed, compressed, function (response) {
-  
-  })
-*/
-}
-
-// Write out the information we've logged about URL status in the 'glob' to 
-// permanent text files.
-function taskFive (glob, dirs, xml, callback) {
-  var pingLog = path.join(dirs["logs"], "linkage-status.csv");
-  var deadLog = path.join(dirs["logs"], "dead-linkages.csv");
-  var uniqueLog = path.join(dirs["logs"], "unique-linkages.csv");
-  
-  async.parallel([
-    function (callback) {
-      handle.linkageLogger(glob["status"], pingLog, function () {
-        callback();
-      })
-    },
-    function (callback) {
-      handle.linkageLogger(glob["dead"], deadLog, function () {
-        callback();
-      })
-    },
-    function (callback) {
-      handle.linkageLogger(glob["unique"], uniqueLog, function () {
-        callback();
-      })
-    }
-  ])
-}
-
-// Execute all of the code.  This part is tricky, because we need to throttle 
-// the flow of data so that our PCs don't crash.  I've been accomplishing this
-// with the 'async' library (look at the waterfall function which executes all
-// of those numbered functions), but the load changes everytime a new process 
-// is added.
-function doEverything () {
-  // Build the 'glob'
-  var DataStore = function () {
-    var linkages = {};
-    linkages.unique = [];
-    linkages.status = [];
-    linkages.dead = [];
-    return linkages;
-  };
-  var ds = new DataStore();
-  
-  // Establish a base working directory
+function parseCsw () {
   var base = argv.out ? argv.out : path.dirname(require.main.filename);
-
-  // Now build our output directories in the base working directory
   var dirs = utility.buildDirs(base);
 
-  var queue = async.queue(function (task, callback) {
-      taskOne(task, function () {
-        callback();
-      });
-  }, 10);
-
-  queue.drain = function () {
-    console.log("All items have been processed");
-  }
-
-  // Now build our request URLs and execute the waterfall of processing 
-  // functions.  Async is proving to be invaluable for organizing all of this
-  // asynchronous processing, but right now it's only controlling the flow of
-  // functions local to this file.  I'm starting to think that we're going to
-  // need to do flow control with async throughout the entire project.
-  utility.doRequest(/*33875*/1000, 10, function (data) {
-    var base = "http://geothermaldata.org/csw?";
-    utility.buildUrl(base, data.counter, data.increment, function (getRecords) {
-
+  function throttled (getRecords, callback) {
       parse.parseCsw(getRecords, function (xml) {
-        var recData = {
-          "dirs": dirs,
-          "xml": xml,
+
+        function doDownload (linkages, directory, callback) {
+          
+          function download (linkage, callback) {
+            var parsedUrl = url.parse(linkage);
+            var host = parsedUrl["protocol"] + "//" + parsedUrl["host"];
+            handle.configurePaths(directory, linkage, function (res) {
+              handle.downloadFile(res.directory, res.file, res.linkage, function (error, res) {
+                if (error) console.log(error);
+                console.log(error);
+                // THIS CALLBACK IS NOT GETTING TRIGGERED!!!
+              });
+            })
+          }
+
+          async.each(linkages, download, function (error, result) {
+            if (error) {
+              callback(error);
+            } else {
+              console.log("HERE");
+              callback();
+            }
+          })
         }
-        queue.push(recData, function (error) {
-          if (error) console.log(error);
+
+        var directory = path.join(dirs["record"], xml.fileId);
+        handle.buildDirectory(directory, function () {
+          var outXML = path.join(directory, xml.fileId + ".xml");
+          handle.writeXML(outXML, xml.fullRecord);
+          doDownload(xml.linkages, directory, function () {
+            console.log("HERE");
+          });
         })
       })
+  }
+
+  function getRecordsList () {
+    var xs = [];
+    utility.doRequest(/*33875*/1000, 10, function (x) {
+      var base = "http://geothermaldata.org/csw?";
+      utility.buildUrl(base, x.counter, x.increment, function (getRecords) {
+        xs.push(getRecords);
+      });
     })
+    return xs;
+  }
+
+  var linksList = getRecordsList();
+
+  async.eachSeries(linksList, throttled, function (error, result) {
+    if (error) console.log(error);
+    console.log(result);
   })
 }

--- a/index.js
+++ b/index.js
@@ -108,24 +108,27 @@ function parseCsw () {
       handle.writeXML(outXML);
       async.forEach(data.linkages, function (linkage) {
         utility.checkLinkage(datastore["dead"], linkage, function (linkage) {
-          if (linkage.search("service=WFS") != -1) {
+          if (linkage.search("service=WFS") !== -1) {
             parse.parseGetCapabilitiesWFS(linkage, function (linkages) {
               async.forEach(linkages, function (linkage) {
                 handle.configurePaths(directory, linkage, function (res) {
-                  parse.parseGetFeaturesWFS(res.linkage, res.directory, res.file, function (data) {
-                    console.log("WFS: " + data);
+                  handle.buildDirectory(res.directory, function () {
+                    parse.parseGetFeaturesWFS(res.linkage, res.directory, res.file, function (data) {
+                      console.log("WFS: " + data);
+                    })                    
                   })
                 })
               })
             })
-          } else {
+          }/* else {
             handle.downloadFile(directory, linkage, function (response) {
               console.log(response);
             });
-          }
+          }*/
         })
       })
-    callback("DOWNLOADED: " + directory); 
+      callback();
+//    callback("DOWNLOADED: " + directory); 
     })
   };
 
@@ -141,9 +144,7 @@ function parseCsw () {
             constructor(item, callback);
           },
           function (data, callback) {
-            processor(data, function (response) {
-              console.log(response);
-            });
+            processor(data, callback);
           },
         ], function (error, result) {
           if (error) callback(error);
@@ -160,7 +161,7 @@ function parseCsw () {
   }
   
   function startQueue () {
-    utility.doRequest(33875, 5, function (x) {
+    utility.doRequest(33875, 100, function (x) {
       var base = "http://geothermaldata.org/csw?";
       utility.buildUrl(base, x.counter, x.increment, function (getRecords) {
         queue.push(getRecords);

--- a/index.js
+++ b/index.js
@@ -107,9 +107,15 @@ function parseCsw () {
     handle.buildDirectory(directory, function () {
       handle.writeXML(outXML);
       async.forEach(data.linkages, function (linkage) {
-        handle.downloadFile(directory, linkage, function (res) {
-          console.log(res);         
-        });
+        utility.checkLinkage(datastore["dead"], linkage, function (linkage) {
+          if (linkage.search("service=WFS") != -1) {
+            
+          } else {
+            handle.downloadFile(directory, linkage, function (response) {
+              console.log(response);
+            });
+          }
+        })
       })
     callback("DOWNLOADED: " + directory); 
     })

--- a/index.js
+++ b/index.js
@@ -116,6 +116,7 @@ function parseCsw () {
   };
 
   var queue = async.queue(function (getRecordUrl, callback) {
+    console.log(getRecordUrl);
     parse.parseCsw(getRecordUrl, function (data) {
       async.each(data, function (item) {
         async.waterfall([
@@ -147,7 +148,6 @@ function parseCsw () {
   function startQueue () {
     utility.doRequest(33875, 5, function (x) {
       var base = "http://geothermaldata.org/csw?";
-      console.log(x)
       utility.buildUrl(base, x.counter, x.increment, function (getRecords) {
         queue.push(getRecords);
       });

--- a/index.js
+++ b/index.js
@@ -109,7 +109,15 @@ function parseCsw () {
       async.forEach(data.linkages, function (linkage) {
         utility.checkLinkage(datastore["dead"], linkage, function (linkage) {
           if (linkage.search("service=WFS") != -1) {
-            
+            parse.parseGetCapabilitiesWFS(linkage, function (linkages) {
+              async.forEach(linkages, function (linkage) {
+                handle.configurePaths(directory, linkage, function (res) {
+                  parse.parseGetFeaturesWFS(res.linkage, res.directory, res.file, function (data) {
+                    console.log("WFS: " + data);
+                  })
+                })
+              })
+            })
           } else {
             handle.downloadFile(directory, linkage, function (response) {
               console.log(response);

--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ function parseCsw () {
                 handle.configurePaths(directory, linkage, function (res) {
                   handle.buildDirectory(res.directory, function () {
                     parse.parseGetFeaturesWFS(res.linkage, res.directory, res.file, function (data) {
-                      console.log("WFS: " + data);
+                      
                     })                    
                   })
                 })

--- a/index.js.bak
+++ b/index.js.bak
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+
+var async = require("async");
+var parse = require("./parse");
+var handle = require("./handle");
+var utility = require("./utility");
+var path = require("path");
+var url = require("url");
+var fs = require("fs");
+var _ = require("underscore");
+//var archive = require("./archive");
+
+var argv = require("yargs")
+  .usage("Command line utility for archiving NGDS data on Amazon S3")
+
+  .alias("p", "parse")
+  .describe("Parse a CSW")
+
+  .alias("u", "urls")
+  .describe("Parse and ping all of the CSW linkages")
+
+  .alias("o", "out")
+  .describe("Specify a base directory for process outputs")
+  .argv;
+
+var cmdQueue = [];
+if (argv.parse) cmdQueue.push(parseCsw);
+if (argv.urls) cmdQueue.push(doEverything);
+
+async.series(cmdQueue);
+
+// Build directories for output files and start streaming XML into text files
+function taskOne (task, callback) {
+  var dirs = task["dirs"];
+  var xml = task["xml"];
+
+  var directory = path.join(dirs["record"], xml.fileId);
+  handle.buildDirectory(directory, function () {
+    var outXML = path.join(directory, xml.fileId + ".xml");
+    handle.writeXML(outXML, xml.fullRecord);
+    doDownload(xml.linkages, directory, function () {
+      callback();
+    });
+  })
+};
+
+function doDownload (linkages, directory, callback) {
+  function download (linkage) {
+    var parsedUrl = url.parse(linkage);
+    var host = parsedUrl["protocol"] + "//" + parsedUrl["host"];
+    handle.configurePaths(directory, linkage, function (res) {
+      console.log(res);
+      handle.downloadFile(res.directory, res.file, res.linkage, function (error) {
+        if (error) console.log(error);
+      });
+    })
+  }
+
+  async.each(linkages, download, function (error) {
+    if (error) {
+      callback(error);
+    } else {
+      callback();
+    }
+  })
+}
+
+// 'Glob' is a global object generated to keep track of URL status, in-memory.
+// Ping each unique base URL and return a status to the 'glob'.
+function taskTwo (glob, dirs, xml, callback) {
+  async.each(xml.linkages, function (linkage) {
+    var parsedUrl = url.parse(linkage);
+    var host = parsedUrl["protocol"] + "//" + parsedUrl["host"];
+    if (_.indexOf(glob["unique"], host) === -1) {
+      glob["unique"].push(host);  
+
+      handle.pingUrl(host, function (error, response) {
+        if (error) {
+          error["ping"] = "DEAD";
+          glob["dead"].push(error);
+          glob["status"].push(error);
+        };
+
+        if (response) {
+          response["ping"] = "ALIVE";
+          glob["status"].push(response);
+        };
+      })
+    }
+  });
+  callback(null);
+}
+
+// This function is kind of a mess right now, I'll probably work on it tonight.
+// Here we download the various kinds of data from each linkage.  The tricky 
+// part that I'm wrestling with is how to return when ALL of the links have been
+// downloaded, so that we can zip that sucka and send it to S3.
+function taskThree (glob, dirs, xml, callback) {
+  var directory = path.join(dirs["record"], xml.fileId);
+  var dead = _.map(glob["dead"], function (record) {
+    return record["linkage"];
+  });
+
+  async.each(xml.linkages, handle.downloadLinkage.bind(null, directory, dead, handle), function (error) {
+    if (error) {
+      callback(error);
+    } else {
+      console.log(directory);
+    callback(null, dirs, xml.fileId);
+    }
+  });
+}
+
+// Pretty simply, just zip up a file
+function taskFour (dirs, directory, callback) {
+  console.log(dirs, directory);
+/*
+  var uncompressed = path.join(dirs["record"], directory);
+  var compressed = path.join(dirs["archive"], directory + ".zip");
+  handle.compressDirectory(uncompressed, compressed, function (response) {
+  
+  })
+*/
+}
+
+// Write out the information we've logged about URL status in the 'glob' to 
+// permanent text files.
+function taskFive (glob, dirs, xml, callback) {
+  var pingLog = path.join(dirs["logs"], "linkage-status.csv");
+  var deadLog = path.join(dirs["logs"], "dead-linkages.csv");
+  var uniqueLog = path.join(dirs["logs"], "unique-linkages.csv");
+  
+  async.parallel([
+    function (callback) {
+      handle.linkageLogger(glob["status"], pingLog, function () {
+        callback();
+      })
+    },
+    function (callback) {
+      handle.linkageLogger(glob["dead"], deadLog, function () {
+        callback();
+      })
+    },
+    function (callback) {
+      handle.linkageLogger(glob["unique"], uniqueLog, function () {
+        callback();
+      })
+    }
+  ])
+}
+
+// Execute all of the code.  This part is tricky, because we need to throttle 
+// the flow of data so that our PCs don't crash.  I've been accomplishing this
+// with the 'async' library (look at the waterfall function which executes all
+// of those numbered functions), but the load changes everytime a new process 
+// is added.
+function doEverything () {
+  // Build the 'glob'
+  var DataStore = function () {
+    var linkages = {};
+    linkages.unique = [];
+    linkages.status = [];
+    linkages.dead = [];
+    return linkages;
+  };
+  var ds = new DataStore();
+  
+  // Establish a base working directory
+  var base = argv.out ? argv.out : path.dirname(require.main.filename);
+
+  // Now build our output directories in the base working directory
+  var dirs = utility.buildDirs(base);
+
+  var queue = async.queue(function (task, callback) {
+      taskOne(task, function () {
+        callback();
+      });
+  }, 10);
+
+  queue.drain = function () {
+    console.log("All items have been processed");
+  }
+
+  // Now build our request URLs and execute the waterfall of processing 
+  // functions.  Async is proving to be invaluable for organizing all of this
+  // asynchronous processing, but right now it's only controlling the flow of
+  // functions local to this file.  I'm starting to think that we're going to
+  // need to do flow control with async throughout the entire project.
+  utility.doRequest(/*33875*/1000, 10, function (data) {
+    var base = "http://geothermaldata.org/csw?";
+    utility.buildUrl(base, data.counter, data.increment, function (getRecords) {
+
+      parse.parseCsw(getRecords, function (xml) {
+        var recData = {
+          "dirs": dirs,
+          "xml": xml,
+        }
+        queue.push(recData, function (error) {
+          if (error) console.log(error);
+        })
+      })
+    })
+  })
+}

--- a/parse/index.js
+++ b/parse/index.js
@@ -61,6 +61,8 @@ module.exports = {
       })
       .pipe(saxParser);
 
+    var data = [];
+
     fullRecord.on("match", function (xml) {
       var idReg = new RegExp(/<gmd:fileIdentifier><gco:CharacterString>(.*?)<\/gco:CharacterString><\/gmd:fileIdentifier>/g);
       var urlReg = new RegExp(/<gmd:URL>(.*?)<\/gmd:URL>/g);
@@ -73,14 +75,16 @@ module.exports = {
         linkages.push(match[1]);
       };
 
-      if (typeof callback === "function") {
-        callback({
-          "fileId": fileId,
-          "linkages": linkages,
-          "fullRecord": xml,
-        })
-      }
+      data.push({
+        "fileId": fileId,
+        "linkages": linkages,
+        "fullRecord": xml,
+      })
     });
+
+    fullRecord.on("end", function () {
+      callback(data);
+    })
   },
   // Given an array of linkage URLs, pull out the WFS getCapabilities URLs and 
   // ping them.  If URL returns 200, then pull out the getFeatures service 

--- a/parse/index.js
+++ b/parse/index.js
@@ -91,38 +91,36 @@ module.exports = {
   // endpoint and the typeNames.  If the typeName matches 'aasg:WellLog', then 
   // construct a getFeatures URL and pass it to the callback.
   parseGetCapabilitiesWFS: function (linkage, callback) {
-    if (linkage.search("service=WFS") != -1) {
-      var saxParser = sax.createStream(true, {lowercasetags: true, trim: true});
-      var capabilities = new saxpath.SaXPath(saxParser, "/wfs:WFS_Capabilities");
-      
-      var options = {
-        "url": linkage,
-        "headers": {
-        "Content-type": "text/xml;charset=utf-8",
-        }      
-      };
+    var saxParser = sax.createStream(true, {lowercasetags: true, trim: true});
+    var capabilities = new saxpath.SaXPath(saxParser, "/wfs:WFS_Capabilities");
 
-      request(linkage, function (error, response) {
-        if (!error && response.statusCode == 200) {
-          request(options).pipe(saxParser);
-          capabilities.on("match", function (xml) {
-            var doc = new dom().parseFromString(xml);
-            var httpGetPath = xpath(doc, "//ows:OperationsMetadata/ows:Ope" +
-                                         "ration/ows:DCP/ows:HTTP/ows:Get/" +
-                                         "@xlink:href");
-            var typeNamePath = xpath(doc, "//wfs:FeatureTypeList/wfs:Featu" +
-                                          "reType/wfs:Name");
-            var endpoint = httpGetPath[0].value;
-            
-            var getFeatures = _.map(typeNamePath, function (typeName) {
-              return endpoint + "request=GetFeature&service=WFS&version=" +
-                     "2.0.0&typeNames=" + typeName.firstChild.data;
-            });
-            callback(getFeatures);
-          })
-        }
-      });
-    }
+    var options = {
+      "url": linkage,
+      "headers": {
+      "Content-type": "text/xml;charset=utf-8",
+      }      
+    };
+
+    request(linkage, function (error, response) {
+      if (!error && response.statusCode == 200) {
+        request(options).pipe(saxParser);
+        capabilities.on("match", function (xml) {
+          var doc = new dom().parseFromString(xml);
+          var httpGetPath = xpath(doc, "//ows:OperationsMetadata/ows:Ope" +
+                                       "ration/ows:DCP/ows:HTTP/ows:Get/" +
+                                       "@xlink:href");
+          var typeNamePath = xpath(doc, "//wfs:FeatureTypeList/wfs:Featu" +
+                                        "reType/wfs:Name");
+          var endpoint = httpGetPath[0].value;
+          
+          var getFeatures = _.map(typeNamePath, function (typeName) {
+            return endpoint + "request=GetFeature&service=WFS&version=" +
+                   "2.0.0&typeNames=" + typeName.firstChild.data;
+          });
+          callback(getFeatures);
+        })
+      }
+    });
   },
   // Given a WFS getFeatures URL, stream stream out all of the data associated 
   // with the parent tag specified in the 'feature' variable.  On each match,

--- a/parse/index.js
+++ b/parse/index.js
@@ -158,19 +158,28 @@ module.exports = {
 
         console.log(xml);
 
-        var logUrls = [];
-
-        var logUri = xml.match("<aasg:LogURI>(.*?)</aasg:LogURI>");
-        if (logUri) logUrls.push(logUri[1]);
-        
-        var wellUri = xml.match("<aasg:WellBoreURI>(.*?)</aasg:WellBoreURI>");
-        if (wellUri) logUrls.push(wellUri[1]);
-        
+        var logInfo = {};
+        logInfo["linkages"] = [];
         var fileUrl = xml.match("<aasg:ScannedFileURL>(.*?)</aasg:ScannedFileURL>");
-        if (fileUrl) logUrls.push(fileUrl[1]);
 
-        var lasUrl = xml.match("<aasg:LASFileURL>(.*?)</aasg:LASFileURL>");
-        if (lasUrl) logUrls.push(lasUrl[1]);
+        if (fileUrl) {
+          fileUrl = fileUrl[1];
+          var illegalChars - [",", ";", "|"];
+          _.each(illegalChars, function (char) {
+            if (fileUrl.indexOf(char) > -1) {
+              files = fileUrl.split(char);
+              _.each(files, function (file) {
+                logInfo["linkages"].push(file);
+              })
+            } else {
+              logInfo["linkages"].push(fileUrl);
+            }            
+          });
+
+          var filePath = fileUrl.split("/").pop();
+          var fileSplit = filePath.split(".")[1];
+          logInfo["fileId"] = fileSplit + ".xml";
+        }
 
         if (typeof callback === "function") {
 
@@ -206,6 +215,9 @@ module.exports = {
       })
     }
   },
+  parseWellLogs: function (data) {
+
+  }
 };
 
 

--- a/utility/index.js
+++ b/utility/index.js
@@ -51,10 +51,6 @@ module.exports = {
         counter += increment;
         callback({"counter": counter, "increment": increment});
       }
-      if (counter === holder) {
-        increment = (last - holder);
-        callback({"counter": counter, "increment": increment});
-      }
     })
   },
   _scaleRequest: function (total, increment, callback) {

--- a/utility/index.js
+++ b/utility/index.js
@@ -1,6 +1,7 @@
 var fs = require("fs");
 var path = require("path");
 var url = require("url");
+var _ = require("underscore");
 
 module.exports = {
   buildDirs: function (base) {
@@ -37,6 +38,18 @@ module.exports = {
         + startPosition + "&maxRecords=" + maxRecords + "&outputSchema="
         + outputSchema + "&typeNames=" + typeNames + "&version=" + version
     })
+  },
+  checkLinkage: function (datastore, linkage, callback) {
+    var host = url.parse(linkage)["host"];
+    var dead = _.map(datastore, function (record) {
+      if (record) {
+        return record["linkage"];        
+      }
+    });
+
+    if (_.indexOf(dead, host) === -1) {
+      callback(linkage);
+    }
   },
   doRequest: function (total, increment, callback) {
     this._scaleRequest(total, increment, function (response) {


### PR DESCRIPTION
A major effort to tame asynchronous processes.  Your operating system has a limit of how many files can be open at a single time.  Normally when automating I/O tasks, this isn't a problem because your program operates on a single file at a time.  In the asynchronous I/O world, it's possible that you'll have thousands of files open at the same time -- which will push the open files limit and crash your program.

So, the solution then is to modularize the flow of data through the program.  This means splitting chunks of data into groups and triggering those groups synchronously, but still running all processes within the groups asynchronously.  Easy, right?  Well it would be if Node.js had no bugs...

Either an "end" or an "error" message will be emitted when a stream of data is finished piping to an output file.  Both of these events should tell the process to then close that file.  For "end" events, this always works as it should.  For "error" events, there is a known bug called the "file descriptor memory leak" which happens when a stream process has emitted a termination command but has not terminated -- so it stays open in memory.  When dealing with streaming data over a network, we're always going to have lots of errors that we cannot predict and in Node-flavored file I/O it means that we'll hit the too many open files error.

The code in this merge fixes all of these open file errors and does pretty much everything (including compressing data into zips) except interaction with S3.  
